### PR TITLE
Fix for unregister on ICS

### DIFF
--- a/library/src/org/jraf/android/util/activitylifecyclecallbackscompat/ActivityLifecycleCallbacksWrapper.java
+++ b/library/src/org/jraf/android/util/activitylifecyclecallbackscompat/ActivityLifecycleCallbacksWrapper.java
@@ -71,4 +71,16 @@ import android.os.Bundle;
     public void onActivityDestroyed(Activity activity) {
         mCallback.onActivityDestroyed(activity);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ActivityLifecycleCallbacksWrapper)) return false;
+        return ((ActivityLifecycleCallbacksWrapper) o).mCallback == mCallback;
+    }
+
+    @Override
+    public int hashCode() {
+        return mCallback.hashCode();
+    }
 }

--- a/library/src/org/jraf/android/util/activitylifecyclecallbackscompat/ApplicationHelper.java
+++ b/library/src/org/jraf/android/util/activitylifecyclecallbackscompat/ApplicationHelper.java
@@ -76,7 +76,7 @@ public class ApplicationHelper {
      * @param application The application with which to unregister the callback.
      * @param callback The callback to unregister.
      */
-    public void unregisterActivityLifecycleCallbacks(Application application, ActivityLifecycleCallbacksCompat callback) {
+    public static void unregisterActivityLifecycleCallbacks(Application application, ActivityLifecycleCallbacksCompat callback) {
         if (PRE_ICS) {
             preIcsUnregisterActivityLifecycleCallbacks(callback);
         } else {


### PR DESCRIPTION
The unregisterActivityLifecycleCallbacks method on ApplicationHelper is not static like registerActivityLifecycleCallbacks, and unregistering callbacks on ICS and higher isn't working since a new instance of the callback wrapper is created in unregister.

I've fixed these issues by making the helper method static and overriding the equals method on ActivityLifecycleCallbacksWrapper.
