### PR TITLE
Clarify API level in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Android ActivityLifecycleCallbacks Compatibility Library
 ========================================================
 
 A 'compatibility' version of the ActivityLifecycleCallbacks APIs (http://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks.html)
-that were introduced on Android 4.
+that were introduced in Android 4 (API Level 14).
 
 This library works on Android 1+.
 


### PR DESCRIPTION
It took me ages to work out why somebody would create a compatibility library in 2013 for a feature added to Android in version 4 until I clicked through to the Android documentation and saw API Level 14. I have added the API level to the README to make this more clear.

I'm so used to people saying ICS that "Android 4" hardly means anything to me!
